### PR TITLE
Add heat curves per zone

### DIFF
--- a/custom_components/airahome/sensor.py
+++ b/custom_components/airahome/sensor.py
@@ -1459,8 +1459,8 @@ class AiraCurveSensor(AiraSensorBase):
             heating: bool = True
     ) -> None:
         super().__init__(coordinator, entry)
-        self._attr_name = f"{'Heating' if heating else 'Cooling'} Curve Zone {zone}"
-        self._attr_unique_id = f"{self._device_uuid}_curve_zone_{zone}"
+        self._attr_name = f"Zone {zone} {'Heating' if heating else 'Cooling'} Curve"
+        self._attr_unique_id = f"{self._device_uuid}_zone_{zone}_{'heating' if heating else 'cooling'}_curve"
         self._zone = zone
         self._heating = heating
 


### PR DESCRIPTION
This PR adds support for heat curves. It returns a single float which is the calculated supply temperature for the current outdoor temperature, and the attributes contain the Ambient and Supply temperature lists, which is a format convenient for plotting. Here's an example created with [https://github.com/dbuezas/lovelace-plotly-graph-card](https://github.com/dbuezas/lovelace-plotly-graph-card)
<img width="429" height="381" alt="image" src="https://github.com/user-attachments/assets/832cca56-951d-4ed7-be21-93777705b729" />
YAML for that is:
<img width="774" height="295" alt="image" src="https://github.com/user-attachments/assets/0f00cc58-789e-4dff-af6a-953221104f1c" />

This is a first working version, and would benefit from more testing and code review (e.g. I only have one zone, so haven't tested more).