### PR TITLE
Handle uninitialised LED pattern sensor native_value

### DIFF
--- a/custom_components/airahome/sensor.py
+++ b/custom_components/airahome/sensor.py
@@ -1321,6 +1321,10 @@ class AiraLEDPatternSensor(AiraSensorBase):
     @property
     def icon(self) -> str:
         """Return the icon based on LED pattern."""
+        if not self.native_value:
+            _LOGGER.debug("LED pattern sensor native_value is None")
+            return "mdi:lightbulb-question"
+        
         pattern = self.native_value.upper()
         if pattern is None:
             return "mdi:lightbulb-off"


### PR DESCRIPTION
This PR is a fix for this issue seen in my logs:
```
2025-11-08 11:34:57.626 ERROR (MainThread) [homeassistant.components.sensor] Error adding entity None for domain sensor with platform airahome
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 910, in _async_add_entity
    original_icon=entity.icon,
                  ^^^^^^^^^^^
  File "/config/custom_components/airahome/sensor.py", line 1332, in icon
    pattern = self.native_value.upper()
              ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'upper'
```